### PR TITLE
Hotkeys: Add ctrl + shift + z windows shortcut for redo

### DIFF
--- a/packages/slate-hotkeys/src/index.js
+++ b/packages/slate-hotkeys/src/index.js
@@ -43,7 +43,7 @@ const APPLE_HOTKEYS = {
 const WINDOWS_HOTKEYS = {
   deleteWordBackward: 'ctrl+shift?+backspace',
   deleteWordForward: 'ctrl+shift?+delete',
-  redo: 'ctrl+y',
+  redo: ['ctrl+y', 'ctrl+shift+z'],
 }
 
 /**


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

It is adding hotkeys that were already implemented in original repo https://github.com/ianstormtaylor/slate/blob/main/packages/slate-react/src/utils/hotkeys.ts#L44

#### Does this fix any issues or need any specific reviewers?

Fixes: https://github.com/grafana/grafana/issues/28658
Reviewers: @kaydelaney 
