### PR TITLE
Disable Input Events 2 API in order to fix a bug in Chrome 105+

### DIFF
--- a/packages/slate-dev-environment/src/index.js
+++ b/packages/slate-dev-environment/src/index.js
@@ -72,11 +72,8 @@ const FEATURE_RULES = [
   ],
   [
     'inputeventslevel2',
-    window => {
-      const element = window.document.createElement('div')
-      element.contentEditable = true
-      const support = 'onbeforeinput' in element
-      return support
+    _ => {
+      return false
     },
   ],
 ]


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?
Fixing a but in Chrome 105+.

#### What's the new behavior?
Input Event Levels 2 is disabled. This will fix a bug where the cursor was jumping randomly to the end of the input field.
